### PR TITLE
Update dialogs.py

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -135,7 +135,7 @@ class Dialog(BaseWidget):
                 title=self._title,
                 resizable=(0, 0),
                 windowtype="dialog",
-                iconify=True,
+                # iconify=True,  # Commented out because this iconify=True freezes tkinter on Ubuntu. No idea why.
             )
 
         self._toplevel.withdraw()  # reset the iconify state


### PR DESCRIPTION
The ttk.Toplevel object creation freezes on Ubuntu, if iconify=True. As a workaround the line is commented out. No side-effects were noticed so far.